### PR TITLE
Updated EPEL and RabbitMQ to latest versions

### DIFF
--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -4,15 +4,14 @@ FROM centos
 RUN yum install -y net-tools pwgen wget curl tar unzip mlocate logrotate
 
 # Install base the EPEL repo
-RUN rpm -Uvh http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
+RUN rpm -Uvh http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
 
 # Install RabbitMQ deps
 RUN rpm --import https://www.rabbitmq.com/rabbitmq-signing-key-public.asc
 
 RUN yum install -y erlang
 
-RUN yum install -y  http://www.rabbitmq.com/releases/rabbitmq-server/v3.5.6/rabbitmq-server-3.5.6-1.noarch.rpm
+RUN yum install -y  http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.5/rabbitmq-server-3.6.5-1.noarch.rpm
 
 # Allow triggerable events on the first time running
 RUN touch /tmp/firsttimerunning
-


### PR DESCRIPTION
Install fails because EPEL version no longer exists.
Both EPEL and RabbitMQ were updated and the scripts run perfectly 👍 